### PR TITLE
Improved connectivity checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
       python : "3.5"
       env: CONDA_PY=35  CONDA_NPY=111
 before_install:
-  - tools/install_miniconda.sh
+  - source tools/install_miniconda.sh
   - conda config --set always_yes true
   - conda config --add channels omnia
   - conda install conda-build nose

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -117,3 +117,7 @@ Version 0.2.5 (Beta):
     - Fix MSC-related problems
 
 Upcoming:
+
+    - New and better algorithm ("reversible_pathways") for detecting the ergodically connected set of Markov states
+    - Changed meaning of "post_hoc_RE" and "BAR_variance" algorithms.
+      They used to be stricter versions of "summed_count_matrix", now they are based on "reversible_pathways".

--- a/test/test_3_2_model.py
+++ b/test/test_3_2_model.py
@@ -73,7 +73,6 @@ def draw_transition_counts(transition_matrices, n_samples, x0):
 class TestThreeTwoModel(object):
     @classmethod
     def setup_class(cls):
-        np.random.seed(7777)
         cls.energy = np.array([1.0, 2.0, 0.0], dtype=np.float64)
         cls.bias_energies = np.array([[0.0, 0.0, 0.0], 2.0 - cls.energy], dtype=np.float64)
         cls.stationary_distribution = np.exp(-cls.energy) / np.exp(-cls.energy).sum()

--- a/test/test_3_2_model.py
+++ b/test/test_3_2_model.py
@@ -73,6 +73,7 @@ def draw_transition_counts(transition_matrices, n_samples, x0):
 class TestThreeTwoModel(object):
     @classmethod
     def setup_class(cls):
+        np.random.seed(7777)
         cls.energy = np.array([1.0, 2.0, 0.0], dtype=np.float64)
         cls.bias_energies = np.array([[0.0, 0.0, 0.0], 2.0 - cls.energy], dtype=np.float64)
         cls.stationary_distribution = np.exp(-cls.energy) / np.exp(-cls.energy).sum()

--- a/test/test_cset.py
+++ b/test/test_cset.py
@@ -62,12 +62,6 @@ class TestCset(object):
         np.testing.assert_allclose(csets[0], np.array([1]))
         np.testing.assert_allclose(csets[1], np.array([0, 1]))
         np.testing.assert_allclose(projected_cset, np.array([0,1]))
-    # def test_strong_in_every_ensemble(self):
-    #     csets, projected_cset = cset.compute_csets_TRAM(
-    #         'strong_in_every_ensemble', self.state_counts, self.count_matrices, self.tram_sequence)
-    #     np.testing.assert_allclose(csets[0], np.array([1]))
-    #     np.testing.assert_allclose(csets[1], np.array([0, 1]))
-    #     np.testing.assert_allclose(projected_cset, np.array([0,1]))
     def test_cset_neighbors(self):
         csets, projected_cset = cset.compute_csets_TRAM(
             'neighbors', self.state_counts, self.count_matrices, ttrajs=self.ttrajs,

--- a/test/test_cset.py
+++ b/test/test_cset.py
@@ -19,7 +19,43 @@ import numpy as np
 import thermotools.cset as cset
 import thermotools.util as util
 
-class TestCset(object):
+class TestCsetBasicReversiblyUnconnected(object):
+    @classmethod
+    def setup_class(cls):
+        # connected only according to the criteria of summed_count_matrix but not reversible_pathways
+        cls.count_matrices = np.zeros((2, 2, 2))
+        cls.count_matrices[0, :, :] = np.array([[0, 0], [1, 0]])
+        cls.count_matrices[1, :, :] = np.array([[0, 1], [0, 0]])
+    def test_basic_reversible_pathways(self):
+        csets, projected_cset = cset.compute_csets_dTRAM('reversible_pathways', self.count_matrices)
+        np.testing.assert_equal(len(projected_cset), 1)
+        np.testing.assert_equal(len(csets[0]), 1)
+        np.testing.assert_equal(csets[1], csets[0])
+    def test_basic_summed_count_matrix(self):
+        csets, projected_cset = cset.compute_csets_dTRAM('summed_count_matrix', self.count_matrices)
+        np.testing.assert_equal(csets[0], np.array([0, 1]))
+        np.testing.assert_equal(csets[1], np.array([0, 1]))
+        np.testing.assert_equal(projected_cset, np.array([0, 1]))
+
+class TestCsetBasicReversiblyConnected(object):
+    @classmethod
+    def setup_class(cls):
+        # conneced according to the criteria of both reversible_pathways and summed_count_matrix
+        cls.count_matrices = np.zeros((2, 3, 3))
+        cls.count_matrices[0, :, :] = np.array([[0, 1, 0], [0, 0, 0], [0, 0, 0]])
+        cls.count_matrices[1, :, :] = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
+    def test_basic_reversible_pathways(self):
+        csets, projected_cset = cset.compute_csets_dTRAM('reversible_pathways', self.count_matrices)
+        np.testing.assert_equal(projected_cset, [0, 1, 2])
+        np.testing.assert_equal(csets[0], [0, 1])
+        np.testing.assert_equal(csets[1], [0, 1, 2])
+    def test_basic_summed_count_matrix(self):
+        csets, projected_cset = cset.compute_csets_dTRAM('summed_count_matrix', self.count_matrices)
+        np.testing.assert_equal(projected_cset, [0, 1, 2])
+        np.testing.assert_equal(csets[0], [0, 1])
+        np.testing.assert_equal(csets[1], [0, 1, 2])
+
+class TestCsetThermodynamicOverlap(object):
     @classmethod
     def setup_class(cls):
         m1 = 10
@@ -58,6 +94,13 @@ class TestCset(object):
     def test_summed_count_matrix(self):
         csets, projected_cset = cset.compute_csets_TRAM(
             'summed_count_matrix', self.state_counts, self.count_matrices,
+            ttrajs=self.ttrajs, dtrajs=self.dtrajs, bias_trajs=self.bias_trajs)
+        np.testing.assert_allclose(csets[0], np.array([1]))
+        np.testing.assert_allclose(csets[1], np.array([0, 1]))
+        np.testing.assert_allclose(projected_cset, np.array([0,1]))
+    def test_reversible_pathways(self):
+        csets, projected_cset = cset.compute_csets_TRAM(
+            'reversible_pathways', self.state_counts, self.count_matrices,
             ttrajs=self.ttrajs, dtrajs=self.dtrajs, bias_trajs=self.bias_trajs)
         np.testing.assert_allclose(csets[0], np.array([1]))
         np.testing.assert_allclose(csets[1], np.array([0, 1]))

--- a/test/test_random_model.py
+++ b/test/test_random_model.py
@@ -68,6 +68,8 @@ def draw_transition_counts(transition_matrices, n_samples, x0):
 class TestRandom(object):
     @classmethod
     def setup_class(cls):
+        cls.rng_state = np.random.get_state()
+        np.random.seed(7777)
         n_therm_states = 4
         n_conf_states = 4
         n_samples = 10000
@@ -93,7 +95,7 @@ class TestRandom(object):
         cls.n_samples = n_samples
     @classmethod
     def teardown_class(cls):
-        pass
+        np.random.set_state(cls.rng_state)
     def setup(self):
         pass
     def teardown(self):

--- a/thermotools/cset.py
+++ b/thermotools/cset.py
@@ -41,20 +41,34 @@ def compute_csets_TRAM(
     Parameters
     ----------
     connectivity : string
-        one of 'summed_count_matrix', 'strong_in_every_ensemble',
+        one of None, 'reversible_pathways', 'summed_count_matrix',
         'neighbors', 'post_hoc_RE' or 'BAR_variance'
         Selects the algorithm for measuring overlap between thermodynamic
-        states.
+        and Markov states.
+
+        None: assume that everything is connected
+
+        reversible_pathways: requires that every state in the connected
+        set can be reached via a pathway of reversible transitions.
+        A reversible transition between two Markov states (within the
+        same thermodynamic state k) is a pair of Markov states that
+        belong to the same strongly connected component of the
+        count matrix (from the respective thermodynamic state k).
+        A pathway of reversible transitions is a list of reversible
+        transitions [(i_1, i_2), (i_2, i_3),..., (i_(N-1), i_N)].
+        The thermodynamic state of the reversible transitions is ignored
+        in constructing the reversible pathways. This is equivalent
+        to assuming that two ensembles overlap at some Markov state
+        whenever thare exist frames from both ensembles in that
+        Markov state.
+
+        largest: alias for reversible_paths
 
         summed_count_matrix: all thermodynamic states are assumed to
         overlap. The connected set is then computed by summing
         the count matrices over all thermodynamic states and
         taking it's largest strongly connected set.
-
-        strong_in_every_ensemble: the dynamics within every thermodynamic
-        state is restricted to that state's largest connected
-        set. This is a very strong restriction and might remove
-        interesting transitions from the data.
+        Not recommended!
 
         neighbors: assume that the data comes from an Umbrella sampling
         simulation and the number of the thermodynamic state matches
@@ -63,26 +77,26 @@ def compute_csets_TRAM(
         the nn'th neighbor (along the order parameter) overlap.
         Technically this is computed by building an adjacency matrix on
         the product space of thermodynamic states and conformational
-        states. The largest strongly connected set of that adjacency
-        matrix determines the TRAM connected sets. In the matrix, the
-        links within each thermodynamic state (between different
-        conformational states) are just copied from the count matrices.
-        The links between different thermodynamic states (within the
-        same conformational state) are set according to the value of nn;
-        if there are samples in both states (k,n) and (l,n) and
-        |l-n|<=nn, a bidirectional link is added.
+        states. The largest connected set of that adjacency matrix
+        determines the TRAM connected sets. In the matrix, the links
+        within each thermodynamic state (between different conformational
+        states) are placed like in the 'reversible_pathway' algorithm.
+        The links between different thermodynamic states k and l (within
+        the same conformational state n) are set according to the value
+        of nn; if there are samples in both states (k,n) and (l,n) and
+        |l-n|<=nn, a link is added.
 
         post_hoc_RE: like neighbors but don't assume any neighborhood
         relations between ensembles but compute them. A combination
-        (i,k) of configuration state i and thermodynamic state k
-        overlaps with (i,l) if a replica exchange simulation [1]_
-        restricted to state i would show at least one transition from k
+        (k,n) of thermodynamic state k and configuration state n
+        overlaps with (l,n) if a replica exchange simulation [1]_
+        restricted to state n would show at least one transition from k
         to l or one transition from from l to k.
         The parameters ttrajs, dtrajs, bias_trajs must be set.
 
         BAR_variance: like neighbors but compute overlap between
-        thermodynamic states using the BAR variance [2]_. Two states (i,k)
-        and (i,l) overlap if the variance of the free energy difference
+        thermodynamic states using the BAR variance [2]_. Two states (k,i)
+        and (l,i) overlap if the variance of the free energy difference
         \Delta f_{kl} (restricted to conformational state i) is less or
         equal than one.
         The parameter ttrajs, dtrajs, bias_trajs must be set.
@@ -143,36 +157,50 @@ def compute_csets_dTRAM(connectivity, count_matrices, nn=None, callback=None):
     Parameters
     ----------
     connectivity : string
-        one of 'summed_count_matrix', 'strong_in_every_ensemble',
-        'neighbors'.
-        Selects the algortihm for measuring overlap between thermodynamic
-        states.
+        one of None, 'reversible_pathways', 'summed_count_matrix' or
+        'neighbors'
+        Selects the algorithm for measuring overlap between thermodynamic
+        and Markov states.
+
+        None: assume that everything is connected
+
+        reversible_pathways: requires that every state in the connected
+        set can be reached via a pathway of reversible transitions.
+        A reversible transition between two Markov states (within the
+        same thermodynamic state k) is a pair of Markov states that
+        belong to the same strongly connected component of the
+        count matrix (from the respective thermodynamic state k).
+        A pathway of reversible transitions is a list of reversible
+        transitions [(i_1, i_2), (i_2, i_3),..., (i_(N-1), i_N)].
+        The thermodynamic state of the reversible transitions is ignored
+        in constructing the reversible pathways. This is equivalent
+        to assuming that two ensembles overlap at some Markov state
+        whenever thare exist frames from both ensembles in that
+        Markov state.
+
+        largest: alias for reversible_paths
 
         summed_count_matrix: all thermodynamic states are assumed to
         overlap. The connected set is then computed by summing
         the count matrices over all thermodynamic states and
         taking it's largest strongly connected set.
-
-        strong_in_every_ensemble: the dynamics within every thermodynamic
-        state is restricted to that state's largest connected
-        set. This is a very strong restriction and might remove
-        interesting transitions from the data.
+        Not recommended!
 
         neighbors: assume that the data comes from an Umbrella sampling
         simulation and the number of the thermodynamic state matches
         the position of the Umbrella along the order parameter. The
         connected set is computed by assuming that only Umbrellas up to
-        the nn'th neighbor (along the order parameter) overlap. 
+        the nn'th neighbor (along the order parameter) overlap.
         Technically this is computed by building an adjacency matrix on
         the product space of thermodynamic states and conformational
-        states. The largest strongly connected set of that adjacency
-        matrix determines the TRAM connted sets. In the matrix, the
-        links within each thermodynamic state (between different
-        conformationals states) are just copied from the count matrices.
-        The links between different thermodynamic states (within the
-        same conformational state) are set according to the value of nn;
-        if there are samples in both states (k,n) and (l,n) and
-        |l-n|<=nn, a bidirectional link is added.
+        states. The largest connected set of that adjacency matrix
+        determines the TRAM connected sets. In the matrix, the links
+        within each thermodynamic state (between different conformational
+        states) are placed like in the 'reversible_pathway' algorithm.
+        The links between different thermodynamic states k and l (within
+        the same conformational state n) are set according to the value
+        of nn; if there are samples in both states (k,n) and (l,n) and
+        |l-n|<=nn, a link is added
 
     count_matrices : numpy.ndarray((T, M, M))
         Count matrices for all T thermodynamic states.
@@ -226,7 +254,19 @@ def _compute_csets(
         csets = [ _np.where(all_state_counts[k, :] > 0)[0] for k in range(n_therm_states) ]
         return csets, cset_projected
     elif connectivity == 'summed_count_matrix':
-        # assume _direct_ overlap between all umbrellas
+        # assume that two thermodynamic states overlap when there are samples from both
+        # ensembles in some Markov state
+        C_sum = count_matrices.sum(axis=0)
+        if equilibrium_state_counts is not None:
+            eq_states = _np.where(equilibrium_state_counts.sum(axis=0) > 0)[0]
+            C_sum[eq_states, eq_states[:, _np.newaxis]] = 1
+        cset_projected = _msmtools.estimation.largest_connected_set(C_sum, directed=True)
+        csets = []
+        for k in range(n_therm_states):
+            cset = _np.intersect1d(_np.where(all_state_counts[k, :] > 0), cset_projected)
+            csets.append(cset)
+        return csets, cset_projected
+    elif connectivity == 'reversible_paths' or connectivity == 'largest':
         C_proxy = _np.zeros((n_conf_states, n_conf_states), dtype=int)
         for C in count_matrices:
             for comp in _msmtools.estimation.connected_sets(C, directed=True):
@@ -240,29 +280,6 @@ def _compute_csets(
             cset = _np.intersect1d(_np.where(all_state_counts[k, :] > 0), cset_projected)
             csets.append(cset)
         return csets, cset_projected
-    elif connectivity == 'strong_in_every_ensemble':
-        # within every thermodynamic state, restrict counts to this state's
-        # largest connected set
-        if equilibrium_state_counts is not None:
-            raise Exception('Connectivity mode "strong_in_every_ensemble" doesn\'t yet support equilibrium data.')
-        csets = []
-        C_sum = _np.zeros((n_conf_states, n_conf_states), dtype=count_matrices.dtype)
-        for k in range(n_therm_states):
-            if callback is not None:
-                callback(maxiter=n_therm_states, iteration_step=k)
-            cset = _msmtools.estimation.largest_connected_set(
-                count_matrices[k, :, :], directed=True)
-            csetT = cset[:, _np.newaxis]
-            C_sum[csetT, cset] += count_matrices[k, csetT, cset]
-            csets.append(cset)
-        projected_cset = _msmtools.estimation.largest_connected_set(C_sum, directed=True)
-        if len(_msmtools.estimation.connected_sets(C_sum, directed=True)) > 1:
-            # if C_sum contained more than one strongly connected component,
-            # restrict the individual csets of the thermodynamic states to
-            # the largest one
-            for k in range(n_therm_states):
-                csets[k] = _np.intersect1d(csets[k], projected_cset)
-        return csets, projected_cset
     elif connectivity in ['neighbors', 'post_hoc_RE', 'BAR_variance']:
         dim = n_therm_states * n_conf_states
         if connectivity == 'post_hoc_RE' or connectivity == 'BAR_variance':

--- a/thermotools/cset.py
+++ b/thermotools/cset.py
@@ -59,10 +59,10 @@ def compute_csets_TRAM(
         The thermodynamic state of the reversible transitions is ignored
         in constructing the reversible pathways. This is equivalent
         to assuming that two ensembles overlap at some Markov state
-        whenever thare exist frames from both ensembles in that
+        whenever there exist frames from both ensembles in that
         Markov state.
 
-        largest: alias for reversible_paths
+        largest: alias for reversible_pathways
 
         summed_count_matrix: all thermodynamic states are assumed to
         overlap. The connected set is then computed by summing
@@ -175,10 +175,10 @@ def compute_csets_dTRAM(connectivity, count_matrices, nn=None, callback=None):
         The thermodynamic state of the reversible transitions is ignored
         in constructing the reversible pathways. This is equivalent
         to assuming that two ensembles overlap at some Markov state
-        whenever thare exist frames from both ensembles in that
+        whenever there exist frames from both ensembles in that
         Markov state.
 
-        largest: alias for reversible_paths
+        largest: alias for reversible_pathways
 
         summed_count_matrix: all thermodynamic states are assumed to
         overlap. The connected set is then computed by summing

--- a/thermotools/cset.py
+++ b/thermotools/cset.py
@@ -397,7 +397,7 @@ def restrict_to_csets(
     state_counts, count_matrices, dtrajs, bias_trajs
 
     state_counts, count_matrices and dtrajs are in the same format
-    as the input parameters. Elements of state_counts and cont_matrices
+    as the input parameters. Elements of state_counts and count_matrices
     not in the connected sets are zero. Elements of dtrajs not in the
     connected sets are negative.
 

--- a/thermotools/cset.py
+++ b/thermotools/cset.py
@@ -266,7 +266,7 @@ def _compute_csets(
             cset = _np.intersect1d(_np.where(all_state_counts[k, :] > 0), cset_projected)
             csets.append(cset)
         return csets, cset_projected
-    elif connectivity == 'reversible_paths' or connectivity == 'largest':
+    elif connectivity == 'reversible_pathways' or connectivity == 'largest':
         C_proxy = _np.zeros((n_conf_states, n_conf_states), dtype=int)
         for C in count_matrices:
             for comp in _msmtools.estimation.connected_sets(C, directed=True):

--- a/tools/install_miniconda.sh
+++ b/tools/install_miniconda.sh
@@ -8,10 +8,12 @@ function install_miniconda {
     echo "installing miniconda to $TARGET"
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then                                 
         platform="Linux"
+        wget http://repo.continuum.io/miniconda/Miniconda-latest-${platform}-x86_64.sh -O mc.sh -o /dev/null
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         platform="MacOSX"
+        curl -o mc.sc http://repo.continuum.io/miniconda/Miniconda-latest-${platform}-x86_64.sh
     fi     
-    wget http://repo.continuum.io/miniconda/Miniconda-latest-${platform}-x86_64.sh -O mc.sh -o /dev/null
+
     bash mc.sh -b -f -p $TARGET
 }
 


### PR DESCRIPTION
addresses issue https://github.com/markovmodel/PyEMMA/issues/1052

This PR adds a new algorithm ('reversible_pathways') for checking connectivity. It allows to identify bad input data for TRAM and dTRAM which has previously caused non-convergence of the estimators.